### PR TITLE
Skript spouštět pouze na PeckaDesign PR

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -89,7 +89,7 @@ setTimeout(function () {
                 $content.append(prContainer);
             }
 
-            var commentsWithPR = $('.timeline-comment-wrapper:contains("PR projekt")');
+            var commentsWithPR = $('.TimelineItem:contains("PR projekt")');
 
             $.each(commentsWithPR, function (i, val) {
                 var prContainer = $('<div class="pr-container"></div>');
@@ -128,7 +128,7 @@ setTimeout(function () {
         }
 
         function findPageLink(pagename) {
-            return $('.timeline-comment-wrapper').first().find('strong:contains(' + pagename + ')').children("a").first().attr("href");
+            return $('.TimelineItem').first().find('strong:contains(' + pagename + ')').children("a").first().attr("href");
         }
     });
 }, 500);

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,13 +1,13 @@
 {
   "manifest_version": 2,
   "name": "PeckaGitHubPlugin",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "PeckaGitHubPlugin",
 
   "content_scripts": [{
     "css": ["style.css"],
     "js": ["jquery.min.js", "content.js"],
-    "matches": ["https://github.com/*"]
+    "matches": ["https://github.com/peckadesign/*/pull/*","https://github.com/peckadesign/*/issues/*"]
   }],
   "background":
   {


### PR DESCRIPTION
Dovolil jsem si upravit, aby se spouštělo jen na PR a jen v peckadesign organizaci. Nikde jinde pak nebude překážet ten proužek, který byl stejně prázdný. 🙂 